### PR TITLE
Doc about configuration in Cargo.toml has a typo

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -30,7 +30,7 @@ Configuration is read from the following (in precedence order)
 - Command line arguments
 - File specified via `--config PATH`
 - `$CRATE/release.toml`
-- `$CRATE/Cargo.toml` (`[metadata.release]` table)
+- `$CRATE/Cargo.toml` (`[package.metadata.release]` table)
 - `$WORKSPACE/release.toml`
 - `$HOME/.release.toml`
 


### PR DESCRIPTION
I discovered this when trying to configure this in my `Cargo.toml`.
I prefer to have the configuration for this utility in there, instead of `release.toml` and was glad it's an option, but when I was trying to use `metadata.release`. Turns out it's `package.metadata.release`.

I hope this helps others with the same issue I encountered.